### PR TITLE
Add nonce auto expiry

### DIFF
--- a/src/controllers/auth/login/controller.ts
+++ b/src/controllers/auth/login/controller.ts
@@ -24,21 +24,32 @@ const authLoginController: RequestHandler = async (req, res, next) => {
     return;
   }
 
-  const processedResult = await processBody({
+  if (!req.session.nonce) {
+    next(new ApiError(400, "Denied due to suspected replay attack"));
+    return;
+  }
+  const loginAttemptResult = await processBody({
     parsedBody: bodyParseResult.data,
     sessionId: req.sessionID,
     nonce: req.session.nonce,
   });
 
-  req.session.nonce = null; // reset the nonce regardless of success/failure
-  if (!processedResult.success) {
-    next(processedResult.error);
+  if (!loginAttemptResult.success) {
+    next(loginAttemptResult.error);
     return;
   }
-  req.session.userData = processedResult.userData;
 
-  res.status(200).json({
-    msg: `Successfully logged in as ${req.session.userData.username}`,
+  // make a new session on successful login
+  req.session.regenerate((regenErr) => {
+    if (regenErr) {
+      next(regenErr);
+      return;
+    }
+
+    req.session.userData = loginAttemptResult.userData;
+    res.status(200).json({
+      msg: `Successfully logged in as ${req.session.userData.username}`,
+    });
   });
 };
 

--- a/src/controllers/auth/login/processBody.ts
+++ b/src/controllers/auth/login/processBody.ts
@@ -1,7 +1,12 @@
 import { z } from "zod";
 import { ApiError } from "middleware/errors";
+import { SessionData } from "express-session";
 import { processAnonUser, processGoogleUser } from "./processUser";
 import AuthLoginBodyValidator from "./validators";
+
+type ProcessAuthLoginBodyReturnType = Promise<
+  ReturnType<typeof processAnonUser> | ReturnType<typeof processGoogleUser>
+>;
 
 async function processAuthLoginBody({
   parsedBody,
@@ -11,7 +16,7 @@ async function processAuthLoginBody({
   parsedBody: z.infer<typeof AuthLoginBodyValidator>;
   sessionId: Parameters<typeof processAnonUser>[1];
   nonce: Parameters<typeof processGoogleUser>[1];
-}) {
+}): ProcessAuthLoginBodyReturnType {
   switch (parsedBody.type) {
     case "anon": {
       const { name } = parsedBody;
@@ -25,9 +30,7 @@ async function processAuthLoginBody({
       return {
         success: false,
         error: new ApiError(400, "Invalid schema in request body"),
-      } as const satisfies
-        | Awaited<ReturnType<typeof processAnonUser>>
-        | Awaited<ReturnType<typeof processGoogleUser>>;
+      };
   }
 }
 

--- a/src/controllers/auth/login/processUser.ts
+++ b/src/controllers/auth/login/processUser.ts
@@ -1,6 +1,5 @@
 import { Request } from "express";
 import { SessionData } from "express-session";
-import { ApiError } from "middleware/errors";
 import verifyGoogleIdToken from "services/auth/google";
 
 type ProcessedResult =
@@ -23,12 +22,6 @@ async function processGoogleUser(
   idToken: Parameters<typeof verifyGoogleIdToken>[0]["idToken"],
   nonce: SessionData["nonce"]
 ): Promise<ProcessedResult> {
-  if (!nonce)
-    return {
-      success: false,
-      error: new ApiError(400, "Denied due to suspected replay attack"),
-    };
-
   const verificationResult = await verifyGoogleIdToken({ idToken, nonce });
   if (!verificationResult.success)
     return { success: false, error: verificationResult.error };

--- a/src/controllers/auth/nonce.ts
+++ b/src/controllers/auth/nonce.ts
@@ -6,7 +6,7 @@ const HEX_BYTE_LENGTH = 2;
 
 declare module "express-session" {
   interface SessionData {
-    nonce: string | null | undefined;
+    nonce: string;
   }
 }
 
@@ -15,6 +15,7 @@ const authNonceController: RequestHandler = (req, res) => {
     .randomBytes(NONCE_HEX_LENGTH / HEX_BYTE_LENGTH)
     .toString("hex");
   req.session.nonce = nonce;
+  req.session.cookie.maxAge = 1000 * 60 * 2; // 2 min
   res.status(200).json({ nonce });
 };
 

--- a/src/services/auth/google.ts
+++ b/src/services/auth/google.ts
@@ -25,7 +25,7 @@ async function verifyGoogleIdToken({
   nonce: requiredNonce,
 }: {
   idToken: string;
-  nonce: NonNullable<SessionData["nonce"]>;
+  nonce: SessionData["nonce"];
 }): Promise<AwaitedReturnValue> {
   const ticket = await client.verifyIdToken({ idToken, audience: clientId });
   const payload = ticket.getPayload();


### PR DESCRIPTION
* The nonce expires every two minutes. This prevents persisted nonces, if the client forgets to validate them.

* Correspondingly, when the client logs in, instead of resetting the nonce, we simply discard the old session and set a new one.